### PR TITLE
Add CCF-event reporting schema in Report layer

### DIFF
--- a/mef/schema/sum_of_products.rnc
+++ b/mef/schema/sum_of_products.rnc
@@ -13,6 +13,13 @@ product =
     literal*
   }
 
-literal =
+literal = literal-event | element not { literal-event }
+
+literal-event =
   element basic-event { name }
-  | element not { element basic-event { name } }
+  | element ccf-event {
+      attribute ccf-group { name },
+      attribute order { xsd:positiveInteger },
+      attribute group-size { xsd:positiveInteger },
+      element basic-event { name }+
+    }


### PR DESCRIPTION
Reporting of events generated by analysis with CCF models
is a bit cumbersome (ugly).
Tools tend to be creative in representing these surrogate events.

The use of reporting schema has been tested in SCRAM,
and it seems to capture the most needed information about the CCF event.

*Note:*
>    "literal-event" is probably not the best name;
    it was chosen just to avoid clutter.
