### PR TITLE
Add specification for importance factor reporting

### DIFF
--- a/mef/report_layer.rst
+++ b/mef/report_layer.rst
@@ -124,6 +124,11 @@ The following importance factors are long-established and commonly calculated:
 
 The definitions of these factors can be found in PSA/PRA literature.
 
+In addition to the importance factors,
+this report section may contain
+the evaluated probability of an event and
+the number of products it occurs in.
+
 .. literalinclude:: schema/importance_factors.rnc
     :name: schema_importance_factors
     :caption: The RNC schema for the XML representation of importance factors

--- a/mef/report_layer.rst
+++ b/mef/report_layer.rst
@@ -87,6 +87,7 @@ The following three categories are so frequent
 that is it worth to normalize the way they are stored into XML files.
 
 - Minimal cut sets (and prime implicants)
+- Importance factors
 - Statistical measures (with moments)
 - Curves
 
@@ -106,6 +107,26 @@ to carry the relevant information.
 .. literalinclude:: schema/sum_of_products.rnc
     :name: schema_sum_of_products
     :caption: The RNC schema for the XML representation of sums-of-products
+    :language: rnc
+
+Importance factors
+------------------
+
+Importance factors are typically computed for basic events
+with the same configurations as for probability analysis.
+The following importance factors are long-established and commonly calculated:
+
+    - Fussel-Vesely Diagnosis Importance Factor (DIF)
+    - Birnbaum Marginal Importance Factor (MIF)
+    - Critical Importance Factor (CIF)
+    - Risk Reduction Worth (RRW)
+    - Risk Achievement Worth (RAW)
+
+The definitions of these factors can be found in PSA/PRA literature.
+
+.. literalinclude:: schema/importance_factors.rnc
+    :name: schema_importance_factors
+    :caption: The RNC schema for the XML representation of importance factors
     :language: rnc
 
 Statistical measures

--- a/mef/schema/importance_factors.rnc
+++ b/mef/schema/importance_factors.rnc
@@ -9,6 +9,8 @@ importance =
 importance-event =
   element basic-event {
     name,
+    attribute occurrence { xsd:nonNegativeInteger }?,
+    attribute probability { xsd:double }?,
     attribute DIF { xsd:double }?,
     attribute MIF { xsd:double }?,
     attribute CIF { xsd:double }?,

--- a/mef/schema/importance_factors.rnc
+++ b/mef/schema/importance_factors.rnc
@@ -1,0 +1,17 @@
+importance =
+  element importance {
+    name?,
+    attribute description { text }?,
+    attribute basic-events { xsd:nonNegativeInteger }?,
+    importance-event*
+  }
+
+importance-event =
+  element basic-event {
+    name,
+    attribute DIF { xsd:double }?,
+    attribute MIF { xsd:double }?,
+    attribute CIF { xsd:double }?,
+    attribute RRW { xsd:double }?,
+    attribute RAW { xsd:double }?,
+  }

--- a/spelling_wordlist.txt
+++ b/spelling_wordlist.txt
@@ -1,12 +1,15 @@
 Ai
+Birnbaum
 CCF
 Fi
+Fussel
 LAnguage
 Napierian
 PSA
 REgular
 Ri
 Schematron
+Vesely
 datatype
 datatypes
 formulae


### PR DESCRIPTION
The commonly calculated importance factors (DIF, MIF, ...)
can be reported in attributes of variables (basic events).
The approach has been tested with SCRAM
and is flexible for new factors or omitted factors.

Note that importance factor reporting is missing for CCF events
because the general representation of them
is not yet accepted into the report layer.
It should be trivial to add CCF event importance factor reporting
(if not cumbersome, though)
after the initial formatting is established.