### PR TITLE
Fix Imply Gate F => G definition

### DIFF
--- a/mef/fault_tree_layer.rst
+++ b/mef/fault_tree_layer.rst
@@ -137,7 +137,7 @@ i.e., two Boolean formulae F and G.
     | **cardinality** | true if at least **l** and at most **h** of the Boolean formulae given as arguments are true, |
     |                 | and false otherwise. **l** and **h** are the two integers (in order) given as arguments.      |
     +-----------------+-----------------------------------------------------------------------------------------------+
-    | **imply**       | F implies G is equivalent to not F and G                                                      |
+    | **imply**       | F implies G is equivalent to (not F or G)                                                     |
     +-----------------+-----------------------------------------------------------------------------------------------+
 
 


### PR DESCRIPTION
There's a minor error in defining this Gate as (~F & G).
The proper definition should be (~F | G).