### PR TITLE
Add support for reporting histogram (density)

### DIFF
--- a/mef/schema/statistical_measure.rnc
+++ b/mef/schema/statistical_measure.rnc
@@ -24,6 +24,7 @@ statistical-measure =
       }
     }?,
     quantiles?,
+    histogram?,
   }
 
 quantiles =
@@ -34,8 +35,16 @@ quantiles =
 
 quantile = element quantile { bin-data }
 
+histogram =
+  element histogram {
+    attribute number { xsd:positiveInteger },
+    bin+
+  }
+
+bin = element bin { bin-data }
+
 bin-data =
   attribute number { xsd:positiveInteger },
-  attribute mean { xsd:double }?,
+  attribute value { xsd:double }?,
   attribute lower-bound { xsd:double }?,
   attribute upper-bound { xsd:double }?


### PR DESCRIPTION
This modifies the "quantiles" schema to support bins
similar (but not the same) to the MEF input.
The distribution/frequency of the data is meant to be in the histogram
as a statistical measure for reporting.

It would be somewhat beneficial
if histogram reporting schema matched exactly
the input histogram-distribution (deviate) schema
since the semantics is the same.