### PR TITLE
Restrict mission-phase instructions in schema

### DIFF
--- a/mef/schema/mission_phase.rnc
+++ b/mef/schema/mission_phase.rnc
@@ -9,5 +9,5 @@ phase-definition =
     attribute time-fraction { xsd:double },
     label?,
     attributes?,
-    instruction*
+    (set-house-event | set-parameter)*
   }


### PR DESCRIPTION
The current specification allows
only 'set-house-event' and 'set-parameter' instructions.

Many other event-tree instructions and instruction directions
don't make sense within the mission-phase construct.