### PR TITLE
Extern library specification

### DIFF
--- a/mef/schema/built_ins.rnc
+++ b/mef/schema/built_ins.rnc
@@ -7,3 +7,28 @@ Weibull = element Weibull { expression, expression, expression, expression }
 periodic-test = element periodic-test { expression+ }
 
 extern-function = element extern-function { name, expression* }
+
+extern-library-definition =
+  element define-extern-library {
+    name,
+    attribute path { xsd:anyURI },
+    attribute system { xsd:boolean }?,
+    attribute decorate { xsd:boolean }?,
+    label?,
+    attributes?
+  }
+
+extern-function-definition =
+  element define-extern-function {
+    name,
+    attribute symbol { Identifier },
+    attribute library { Identifier },
+    label?,
+    attributes?,
+    extern-function-return-type,
+    extern-function-parameter-type*
+  }
+
+extern-function-return-type = extern-function-parameter-type
+
+extern-function-parameter-type = element int { empty } | element double { empty }

--- a/mef/schema/model.rnc
+++ b/mef/schema/model.rnc
@@ -4,7 +4,7 @@ model =
     label?,
     attributes?,
     (model-data
-     |event-tree-definition
+     | event-tree-definition
      | alignment-definition
      | consequence-group-definition
      | consequence-definition
@@ -14,5 +14,7 @@ model =
      | fault-tree-definition
      | substitution-definition
      | CCF-group-definition
+     | extern-library-definition
+     | extern-function-definition
      | include-directive)*
   }

--- a/spelling_wordlist.txt
+++ b/spelling_wordlist.txt
@@ -9,9 +9,13 @@ Ri
 Schematron
 datatype
 datatypes
+de
 formulae
+franca
 iff
 lognormal
 nand
+plugins
 schemas
+whitelist
 xor


### PR DESCRIPTION
The existing extern-function specification doesn't clarify
the origin of functions (issue #37).
This 'extern-library' specification complements the 'extern-function'
by providing a way to define the source library for functions.
'extern-library' is a dynamic library loaded at runtime,
and 'extern-function' is a C function in the library
looked up by its symbol (name).
This is a flexible and cross-platform way to allow extensions
but not without drawbacks (more about this in the spec).

I am not sure what the MEF original 'extern-function' creators wanted it to be,
but it doesn't seem to be fully specified or tool-agnostic (portable).
My proposal is one of ways to clarify and 'empower' this MEF element.
This 'flexible' way of defining extern-function may be a bit tedious to implement
but definitely achievable across tools and platforms (I think).

I have yet to implement it myself and see what can be improved.
Meanwhile, I would love to get your feedback on this proposal.

Closes #37 