### PR TITLE
Replace 'Boolean-value' with 'xsd:boolean'

### DIFF
--- a/mef/schema/expressions.rnc
+++ b/mef/schema/expressions.rnc
@@ -32,7 +32,7 @@ constant = bool | int | float
 
 bool =
   element bool {
-    attribute value { Boolean-value }
+    attribute value { xsd:boolean }
   }
 
 int =

--- a/mef/schema/formula.rnc
+++ b/mef/schema/formula.rnc
@@ -38,7 +38,5 @@ basic-event = element basic-event { reference }
 
 Boolean-constant =
   element constant {
-    attribute value { Boolean-value }
+    attribute value { xsd:boolean }
   }
-
-Boolean-value = "true" | "false"


### PR DESCRIPTION
XML schema provides the Boolean datatype,
which allows "true", "false", "0", "1" for values.
This datatype can be used instead of
custom 'Boolean-value' specification.

The current 'Boolean-value' appears only in the schema,
so the replacement with 'xsd:boolean' will be backwards compatible.