### PR TITLE
Add specification for the MEF version attribute

### DIFF
--- a/mef/model_organization.rst
+++ b/mef/model_organization.rst
@@ -118,3 +118,17 @@ The Model Exchange Format introduces also eighteen constructs.
     :name: schema_model
     :caption: The RNC schema for the XML representation of a model
     :language: rnc
+
+The Model Exchange Format provides a version tag for the root XML element.
+This optional tag indicates the version of the MEF standard
+required by the model.
+To indicate the version of the model itself,
+one can use the extensible attribute system provided by the MEF.
+
+.. code-block:: xml
+
+    <opsa-mef version="2.0d">  <!-- The MEF standard version to process this file -->
+        <attributes>
+            <attribute name="version" value="1.0"/>  <!-- The model version -->
+        </attributes>
+    </opsa-mef>

--- a/mef/schema/model.rnc
+++ b/mef/schema/model.rnc
@@ -1,5 +1,6 @@
 model =
   element opsa-mef {
+    attribute version { xsd:string }?,
     name?,
     label?,
     attributes?,


### PR DESCRIPTION
Models can require certain minimum versions of the MEF
to be processed successfully.
The explicit version specification
helps tools gracefully handle old and new MEF version.

However, the actual format or semantics of MEF version numbers
are not yet specified.