### PR TITLE
Limit XOR and IFF to two arguments

### DIFF
--- a/mef/schema/formula.rnc
+++ b/mef/schema/formula.rnc
@@ -4,8 +4,8 @@ formula =
   | element and { formula+ }
   | element or { formula+ }
   | element not { formula }
-  | element xor { formula+ }
-  | element iff { formula+ }
+  | element xor { formula, formula }
+  | element iff { formula, formula }
   | element nand { formula+ }
   | element nor { formula+ }
   | element atleast {


### PR DESCRIPTION
Currently, XOR and IFF are specified as n-ary connectives.
Besides being rarely used/needed,
these connectives are not intuitive in their associative, n-ary forms.
For example, a naive user may confuse XOR with natural 'either .. or',
which doesn't hold with more than 2 args;
it is rather 'odd' (pun intended :)).

I think those FTA tools that do support these gates
limit the number of arguments to 2 (e.g., graphically).
It would be unreasonable to require generality without a practical need.